### PR TITLE
feat: implementation of streaming mode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ buildNumber.properties
 .idea/
 *.iml
 *.sastoken
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 ### Added
-- N/A
+- feat: Streaming mode based on InputStream using `ClaimCheckStreamingProducerInterceptor` and 
+  `ClaimCheckStreamingDeserializer`.
 
 ### Changed
 - N/A 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ config.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_DESERIALIZER_CLASS
         StringDeserializer.class);
 ```
 
+## Streaming mode
+A streaming mode is implemented based on `java.io.InputStream`, that can help reduce memory usage, since the payload
+does not need to be fully in memory.
+
+Note: you will need to provide an additional header in the Producer (`message-claim-check-payload-size`) as a 
+serialized Long. A convenience method is provided to help set this header:
+`se.irori.kafka.claimcheck.ClaimCheckStreamingUtils.setPayloadSize(Headers headers, long payloadSize)`
+
+```
+# producer
+# Need to have KafkaProducer<T, InputStream>
+# Need to send header message-claim-check-payload-size as Long
+interceptor.classes=se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor
+value.serializer.wrapped.serializer=se.irori.kafka.claimcheck.InputStreamSerializer
+
+# consumer
+# Need to have KafkaConsumer<T, InputStream>
+value.deserializer=se.irori.kafka.claimcheck.ClaimCheckStreamingDeserializer
+```
+
+See example usage in `claim-check-interceptors-azure/.../ProduceConsumeStreamingKafkaAzureIT.java`.
+
 ## Config reference
 
 `claimcheck.backend.class`
@@ -65,7 +87,7 @@ The the byte limit where Kafka record batches above this size are checked in usi
 * Importance: medium
 
 `interceptor.classes`
-Set to `se.irori.kafka.claimcheck.ClaimCheckProducerInterceptor` for the Producer in a Claim Check enabled flow.
+Set to `se.irori.kafka.claimcheck.ClaimCheckProducerInterceptor` for the Producer in a Claim Check enabled flow. If using streaming mode, instead use `ClaimCheckStreamingProducerInterceptor`.
 
 * Type: list
 * Default: null
@@ -79,7 +101,7 @@ Standard Kafka key.serializer option. Used  for the calculation of message size 
 * Importance: medium
 
 `value.deserializer`
-Set to `se.irori.kafka.claimcheck.ClaimCheckDeserializer` for the Consumer in a Claim Check enabled flow.
+Set to `se.irori.kafka.claimcheck.ClaimCheckDeserializer` for the Consumer in a Claim Check enabled flow. If using streaming mode, instead use `ClaimCheckStreamingDeserializer`.
 
 * Type: class
 * Default: null

--- a/claim-check-interceptors-azure-8/src/main/java/se/irori/kafka/claimcheck/azurev8/AzureBlobStorageClaimCheckBackendV8.java
+++ b/claim-check-interceptors-azure-8/src/main/java/se/irori/kafka/claimcheck/azurev8/AzureBlobStorageClaimCheckBackendV8.java
@@ -121,7 +121,7 @@ public class AzureBlobStorageClaimCheckBackendV8 implements ClaimCheckBackend {
     final CloudBlockBlob blob;
     try {
       blob = new CloudBlockBlob(new URI(blobUrl), blobServiceClient.getCredentials());
-    } catch (URISyntaxException | StorageException | RuntimeException e ) {
+    } catch (URISyntaxException | StorageException | RuntimeException e) {
       throw new KafkaStorageException("Bad Azure claim check url: " + blobUrl);
     }
 
@@ -142,7 +142,7 @@ public class AzureBlobStorageClaimCheckBackendV8 implements ClaimCheckBackend {
     final CloudBlockBlob blob;
     try {
       blob = new CloudBlockBlob(new URI(blobUrl), blobServiceClient.getCredentials());
-    } catch (URISyntaxException | StorageException | RuntimeException e ) {
+    } catch (URISyntaxException | StorageException | RuntimeException e) {
       throw new KafkaStorageException("Bad Azure claim check url: " + blobUrl);
     }
 

--- a/claim-check-interceptors-azure-8/src/main/java/se/irori/kafka/claimcheck/azurev8/AzureBlobStorageClaimCheckBackendV8.java
+++ b/claim-check-interceptors-azure-8/src/main/java/se/irori/kafka/claimcheck/azurev8/AzureBlobStorageClaimCheckBackendV8.java
@@ -6,6 +6,7 @@ import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -64,6 +65,11 @@ public class AzureBlobStorageClaimCheckBackendV8 implements ClaimCheckBackend {
     return new ClaimCheck(blockBlobReference.getUri().toString());
   }
 
+  @Override
+  public ClaimCheck checkInStreaming(String topic, InputStream payload, long payloadSize) {
+    throw new UnsupportedOperationException("Not implemented for Azure V8 backend");
+  }
+
   private CloudBlobContainer getCloudBlobContainer(ProducerRecord<byte[], byte[]> largeRecord) {
     CloudBlobContainer cloudBlobContainer =
         topicContainerClients.computeIfAbsent(largeRecord.topic(), topic -> {
@@ -96,6 +102,11 @@ public class AzureBlobStorageClaimCheckBackendV8 implements ClaimCheckBackend {
     }
 
     return byteArrayOutputStream.toByteArray();
+  }
+
+  @Override
+  public InputStream checkOutStreaming(ClaimCheck claimCheck) {
+    throw new UnsupportedOperationException("Not implemented for Azure V8 backend");
   }
 
   @Override

--- a/claim-check-interceptors-azure-8/src/test/java/se/irori/kafka/claimcheck/azurev8/ProduceConsumeStreamingKafkaAzureIT.java
+++ b/claim-check-interceptors-azure-8/src/test/java/se/irori/kafka/claimcheck/azurev8/ProduceConsumeStreamingKafkaAzureIT.java
@@ -1,0 +1,153 @@
+package se.irori.kafka.claimcheck.azurev8;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+import se.irori.kafka.claimcheck.BaseClaimCheckConfig;
+import se.irori.kafka.claimcheck.ClaimCheckSerializer;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingDeserializer;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingUtils;
+import se.irori.kafka.claimcheck.InputStreamSerializer;
+import se.irori.kafka.claimcheck.TestUtils;
+
+/**
+ * Integration test on the KafkaProducer/KafkaConsumer level, against
+ * a realistic Azure backend (Azurite emulator or real backend) and a real Kafka cluster.
+ */
+public class ProduceConsumeStreamingKafkaAzureIT extends AbstractClaimCheckIT {
+
+  KafkaProducer<String, InputStream> producer;
+  KafkaConsumer<String, InputStream> consumer;
+
+  HashMap<String, Object> producerConfig;
+  HashMap<String, Object> consumerConfig;
+
+  private static final String TOPIC = "my-topic";
+  private static final Logger log = LoggerFactory.getLogger(ProduceConsumeStreamingKafkaAzureIT.class);
+
+  @Rule
+  public final AzuriteContainer azuriteContainer = new AzuriteContainer()
+      .withExposedPorts(10000);
+
+  // https://docs.confluent.io/platform/current/installation/versions-interoperability.html
+  // 7.1.x => Kafka 3.1.0
+  @ClassRule
+  public static final KafkaContainer kafkaContainer =
+      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.1.1"));
+
+  @Before
+  public void setUp() {
+    producerConfig = new HashMap<>();
+    injectConfigFromSystemProperties(producerConfig, azuriteContainer, "producer.");
+    // https://github.com/Azure/Azurite#default-storage-account
+
+    // use default value
+    // producerConfig.put(CLAIMCHECK_CHECKIN_UNCOMPRESSED_BATCH_SIZE_OVER_BYTES_CONFIG, 10);
+    producerConfig.putIfAbsent(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG,
+        AzureBlobStorageClaimCheckBackendV8.class);
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        kafkaContainer.getBootstrapServers());
+
+    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        ClaimCheckSerializer.class);
+    producerConfig.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_SERIALIZER_CLASS,
+        InputStreamSerializer.class);
+    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfig.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
+        ClaimCheckStreamingProducerInterceptor.class.getName());
+    producerConfig.put(AzureClaimCheckConfig.Keys.AZURE_CREATE_CONTAINER_IF_NOT_EXISTS,
+        true);
+
+    consumerConfig = new HashMap<>();
+    injectConfigFromSystemProperties(consumerConfig, azuriteContainer, "consumer.");
+    consumerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        kafkaContainer.getBootstrapServers());
+    consumerConfig.putIfAbsent(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG,
+        AzureBlobStorageClaimCheckBackendV8.class);
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        ClaimCheckStreamingDeserializer.class);
+    consumerConfig.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_DESERIALIZER_CLASS,
+        StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "my-group");
+
+    producer = new KafkaProducer<>(producerConfig);
+    consumer = new KafkaConsumer<>(consumerConfig);
+
+    consumer.subscribe(Collections.singletonList(TOPIC));
+  }
+
+  @Test
+  public void testKafkaProduceConsumeStreaming() throws ExecutionException, InterruptedException,
+      IOException {
+    String key = "myKey";
+    String value = TestUtils.getRandomString(1024 * 1024);
+    ProducerRecord<String, InputStream> inputRecord =
+        TestUtils.streamRecordFromString(TOPIC, key, value);
+
+    RecordMetadata recordMetadata = producer.send(inputRecord).get();
+
+    //Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+    //kafkaContainer.followOutput(logConsumer);
+
+    ArrayList<ConsumerRecord<String, InputStream>> consumedRecords = new ArrayList<>();
+    consumer.poll(Duration.ofSeconds(10)).forEach(consumedRecords::add);
+
+    int timeoutS = 60;
+    for (int i = 0; i < 60; i++) {
+      if (consumer.assignment().size() > 0) {
+        break;
+      }
+      Thread.sleep(1000);
+    }
+    assertTrue("no partition assignment within timeout " + timeoutS + "s",
+        consumer.assignment().size() > 0);
+
+    consumer.poll(Duration.ofSeconds(10)).forEach(consumedRecords::add);
+
+    assertEquals(1, consumedRecords.size());
+    ConsumerRecord<String, InputStream> record = consumedRecords.get(0);
+    String keyResult = record.key();
+    long payloadSize = ClaimCheckStreamingUtils.getPayloadSize(record.headers());
+
+    byte[] data = new byte[(int) payloadSize];
+    DataInputStream dis = new DataInputStream(record.value());
+    dis.readFully(data);
+    dis.close();
+
+    String valueResult = new String(data, StandardCharsets.UTF_8);
+    assertEquals(key, keyResult);
+    assertEquals(value, valueResult);
+  }
+
+}

--- a/claim-check-interceptors-azure/src/test/java/se/irori/kafka/claimcheck/azure/ProduceConsumeStreamingKafkaAzureIT.java
+++ b/claim-check-interceptors-azure/src/test/java/se/irori/kafka/claimcheck/azure/ProduceConsumeStreamingKafkaAzureIT.java
@@ -1,0 +1,153 @@
+package se.irori.kafka.claimcheck.azure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+import se.irori.kafka.claimcheck.BaseClaimCheckConfig;
+import se.irori.kafka.claimcheck.ClaimCheckSerializer;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingDeserializer;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor;
+import se.irori.kafka.claimcheck.ClaimCheckStreamingUtils;
+import se.irori.kafka.claimcheck.InputStreamSerializer;
+import se.irori.kafka.claimcheck.TestUtils;
+
+/**
+ * Integration test on the KafkaProducer/KafkaConsumer level, against
+ * a realistic Azure backend (Azurite emulator or real backend) and a real Kafka cluster.
+ */
+public class ProduceConsumeStreamingKafkaAzureIT extends AbstractClaimCheckIT {
+
+  KafkaProducer<String, InputStream> producer;
+  KafkaConsumer<String, InputStream> consumer;
+
+  HashMap<String, Object> producerConfig;
+  HashMap<String, Object> consumerConfig;
+
+  private static final String TOPIC = "my-topic";
+  private static final Logger log = LoggerFactory.getLogger(ProduceConsumeStreamingKafkaAzureIT.class);
+
+  @Rule
+  public final AzuriteContainer azuriteContainer = new AzuriteContainer()
+      .withExposedPorts(10000);
+
+  // https://docs.confluent.io/platform/current/installation/versions-interoperability.html
+  // 7.1.x => Kafka 3.1.0
+  @ClassRule
+  public static final KafkaContainer kafkaContainer =
+      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.1.1"));
+
+  @Before
+  public void setUp() {
+    producerConfig = new HashMap<>();
+    injectConfigFromSystemProperties(producerConfig, azuriteContainer, "producer.");
+    // https://github.com/Azure/Azurite#default-storage-account
+
+    // use default value
+    // producerConfig.put(CLAIMCHECK_CHECKIN_UNCOMPRESSED_BATCH_SIZE_OVER_BYTES_CONFIG, 10);
+    producerConfig.putIfAbsent(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG,
+        AzureBlobStorageClaimCheckBackend.class);
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        kafkaContainer.getBootstrapServers());
+
+    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        ClaimCheckSerializer.class);
+    producerConfig.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_SERIALIZER_CLASS,
+        InputStreamSerializer.class);
+    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfig.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
+        ClaimCheckStreamingProducerInterceptor.class.getName());
+    producerConfig.put(AzureClaimCheckConfig.Keys.AZURE_CREATE_CONTAINER_IF_NOT_EXISTS,
+        true);
+
+    consumerConfig = new HashMap<>();
+    injectConfigFromSystemProperties(consumerConfig, azuriteContainer, "consumer.");
+    consumerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        kafkaContainer.getBootstrapServers());
+    consumerConfig.putIfAbsent(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG,
+        AzureBlobStorageClaimCheckBackend.class);
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        ClaimCheckStreamingDeserializer.class);
+    consumerConfig.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_DESERIALIZER_CLASS,
+        StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "my-group");
+
+    producer = new KafkaProducer<>(producerConfig);
+    consumer = new KafkaConsumer<>(consumerConfig);
+
+    consumer.subscribe(Collections.singletonList(TOPIC));
+  }
+
+  @Test
+  public void testKafkaProduceConsumeStreaming() throws ExecutionException, InterruptedException,
+      IOException {
+    String key = "myKey";
+    String value = TestUtils.getRandomString(1024 * 1024);
+    ProducerRecord<String, InputStream> inputRecord =
+        TestUtils.streamRecordFromString(TOPIC, key, value);
+
+    RecordMetadata recordMetadata = producer.send(inputRecord).get();
+
+    //Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+    //kafkaContainer.followOutput(logConsumer);
+
+    ArrayList<ConsumerRecord<String, InputStream>> consumedRecords = new ArrayList<>();
+    consumer.poll(Duration.ofSeconds(10)).forEach(consumedRecords::add);
+
+    int timeoutS = 60;
+    for (int i = 0; i < 60; i++) {
+      if (consumer.assignment().size() > 0) {
+        break;
+      }
+      Thread.sleep(1000);
+    }
+    assertTrue("no partition assignment within timeout " + timeoutS + "s",
+        consumer.assignment().size() > 0);
+
+    consumer.poll(Duration.ofSeconds(10)).forEach(consumedRecords::add);
+
+    assertEquals(1, consumedRecords.size());
+    ConsumerRecord<String, InputStream> record = consumedRecords.get(0);
+    String keyResult = record.key();
+    long payloadSize = ClaimCheckStreamingUtils.getPayloadSize(record.headers());
+
+    byte[] data = new byte[(int) payloadSize];
+    DataInputStream dis = new DataInputStream(record.value());
+    dis.readFully(data);
+    dis.close();
+
+    String valueResult = new String(data, StandardCharsets.UTF_8);
+    assertEquals(key, keyResult);
+    assertEquals(value, valueResult);
+  }
+
+}

--- a/claim-check-interceptors-core/pom.xml
+++ b/claim-check-interceptors-core/pom.xml
@@ -19,12 +19,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>se.irori.kafka</groupId>
-      <artifactId>claim-check-test-tools</artifactId>
-      <version>1.0.1-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -47,6 +41,8 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+
+
   </dependencies>
 
 </project>

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/BaseClaimCheckConfig.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/BaseClaimCheckConfig.java
@@ -43,11 +43,12 @@ public class BaseClaimCheckConfig extends AbstractConfig {
 
   public static final String INTERCEPTOR_CLASSES_DOCS = "Set to"
       + " `se.irori.kafka.claimcheck.ClaimCheckProducerInterceptor` for the Producer in a"
-      + " Claim Check enabled flow.";
+      + " Claim Check enabled flow. If using streaming mode, "
+      +  "instead use `ClaimCheckStreamingProducerInterceptor`.";
 
   public static final String DESERIALIZER_DOCS = "Set to"
       + " `se.irori.kafka.claimcheck.ClaimCheckDeserializer` for the Consumer in a Claim Check"
-      + " enabled flow.";
+      + " enabled flow. If using streaming mode, instead use `ClaimCheckStreamingDeserializer`.";
 
   public static final String KEY_SERIALIZER_DOCS = "Standard Kafka key.serializer option. Used "
       + " for the calculation of message size to determine if it should be checked in.";

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
@@ -21,6 +21,13 @@ public interface ClaimCheckBackend extends Configurable  {
    */
   ClaimCheck checkIn(ProducerRecord<byte[], byte[]> largeRecord);
 
+  /**
+   * Check in a payload in the underlying storage system, from an input stream.
+   * @param topic Kafka topic from record
+   * @param payload the payload input stream
+   * @param payloadSize the size (number of bytes) that will be provided in the stream.
+   * @return a Claim Check representing a reference to the underlying storage system.
+   */
   ClaimCheck checkInStreaming(String topic, InputStream payload, long payloadSize);
 
   /**
@@ -31,6 +38,12 @@ public interface ClaimCheckBackend extends Configurable  {
    */
   byte[] checkOut(ClaimCheck claimCheck);
 
+  /**
+   * Retrieve a previously stored record as a stream, using the Claim Check (reference).
+   *
+   * @param claimCheck previously issued claim check for this backend
+   * @return the message payload previously checked in, as a stream
+   */
   InputStream checkOutStreaming(ClaimCheck claimCheck);
 
   /**

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
@@ -1,9 +1,8 @@
 package se.irori.kafka.claimcheck;
 
+import java.io.InputStream;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
-
-import java.io.InputStream;
 
 /**
  * A Claim Check storage backend that can store large messages, issue references to them,

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckBackend.java
@@ -3,6 +3,8 @@ package se.irori.kafka.claimcheck;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
 
+import java.io.InputStream;
+
 /**
  * A Claim Check storage backend that can store large messages, issue references to them,
  * and using these references, later retrieve the messages.
@@ -20,6 +22,8 @@ public interface ClaimCheckBackend extends Configurable  {
    */
   ClaimCheck checkIn(ProducerRecord<byte[], byte[]> largeRecord);
 
+  ClaimCheck checkInStreaming(String topic, InputStream payload, long payloadSize);
+
   /**
    * Retrieve a previously stored record, using the Claim Check (reference).
    *
@@ -27,6 +31,8 @@ public interface ClaimCheckBackend extends Configurable  {
    * @return the message payload previously checked in
    */
   byte[] checkOut(ClaimCheck claimCheck);
+
+  InputStream checkOutStreaming(ClaimCheck claimCheck);
 
   /**
    * Close any resources opened to communicate with the backend.

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingDeserializer.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingDeserializer.java
@@ -3,15 +3,14 @@ package se.irori.kafka.claimcheck;
 import static se.irori.kafka.claimcheck.ClaimCheckUtils.getClaimCheckRefFromHeader;
 import static se.irori.kafka.claimcheck.ClaimCheckUtils.isClaimCheck;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Map;
 
 /**
  * Deserializes Kafka messages that are potentially Claim Check messages.

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptor.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptor.java
@@ -1,0 +1,170 @@
+package se.irori.kafka.claimcheck;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import se.irori.kafka.claimcheck.BaseClaimCheckConfig.Keys;
+
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Implementation of the ClaimCheck pattern producer side. Assumes you have also configured
+ * the {@link ClaimCheckSerializer} to catch any propagated errors.
+ *
+ * <p>If the message is above the configured limit, a claim check will be published
+ * in the configured backend, and a reference stored as a header of the message
+ * published in Kafka.
+ */
+public class ClaimCheckStreamingProducerInterceptor<K>
+    implements ProducerInterceptor<K, InputStream> {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(ClaimCheckStreamingProducerInterceptor.class);
+
+  public static final String HEADER_MESSAGE_CLAIM_CHECK = "message-claim-check";
+  public static final String HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE =
+      "message-claim-check-payload-size";
+  public static final String HEADER_MESSAGE_CLAIM_CHECK_ERROR = "message-claim-check-error";
+
+  private long checkinUncompressedSizeOverBytes =
+      BaseClaimCheckConfig.CLAIMCHECK_CHECKIN_UNCOMPRESSED_BATCH_SIZE_OVER_BYTES_DEFAULT;
+
+  private Serializer<K> keySerializer;
+
+  private ClaimCheckBackend claimCheckBackend;
+
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void configure(Map<String, ?> configs) {
+    BaseClaimCheckConfig baseClaimCheckConfig = BaseClaimCheckConfig.validatedConfig(configs);
+    checkinUncompressedSizeOverBytes = baseClaimCheckConfig.getLong(
+      Keys.CLAIMCHECK_CHECKIN_UNCOMPRESSED_BATCH_SIZE_OVER_BYTES_CONFIG);
+
+
+    this.keySerializer = baseClaimCheckConfig
+            .getConfiguredInstance(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, Serializer.class);
+    this.keySerializer.configure(baseClaimCheckConfig.originals(), true);
+
+    this.claimCheckBackend = baseClaimCheckConfig.getConfiguredInstance(
+        Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG, ClaimCheckBackend.class);
+
+    Serializer<?> rootSerializer = baseClaimCheckConfig
+        .getConfiguredInstance(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serializer.class);
+
+    if (!(rootSerializer instanceof ClaimCheckSerializer)) {
+      throw new ConfigException("ClaimCheckProducerInterceptor must be used with"
+          + " ClaimCheckSerializer as value.serializer to guarantee propagation of"
+          + " exceptions to the client.");
+    }
+  }
+
+  @Override
+  public ProducerRecord<K, InputStream> onSend(ProducerRecord<K, InputStream> producerRecord) {
+    try {
+      byte[] longBytes =
+          producerRecord.headers().lastHeader(HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE).value();
+      ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+      buffer.put(longBytes);
+      long payloadSize = buffer.getLong();
+
+      final byte[] keyBytes = keySerializer.serialize(
+          producerRecord.topic(),
+          producerRecord.headers(),
+          producerRecord.key()
+      );
+
+      InputStream payloadStream = producerRecord.value();
+
+      if (isAboveClaimCheckLimit(producerRecord, keyBytes, payloadSize)) {
+        LOG.debug("starting  claim check streaming upload: topic={}, key={}, length={}",
+            producerRecord.topic(), producerRecord.key(), payloadSize);
+        ClaimCheck claimCheck = claimCheckBackend.checkInStreaming(producerRecord.topic(),
+            payloadStream,
+            payloadSize);
+
+        LOG.debug("checked in claim check streaming: topic={}, key={}, ref={}, length={}",
+            producerRecord.topic(), producerRecord.key(), claimCheck.getReference(),
+            payloadSize);
+
+        // note: if using ClaimCheckSerializer this can probably be made to work
+        // somewhat with log compaction, since null will be replaced
+        return new ProducerRecord<>(producerRecord.topic(),
+            producerRecord.partition(),
+            producerRecord.timestamp(),
+            producerRecord.key(),
+            null,
+            producerRecord.headers().add(HEADER_MESSAGE_CLAIM_CHECK, claimCheck.serialize())
+        );
+      } else {
+        LOG.debug("not checking in claim check: topic={}, key={}, length={}",
+            producerRecord.topic(), producerRecord.key(), payloadSize);
+        return producerRecord;
+      }
+    } catch (Exception e) {
+      LOG.error("Error when processing claim check", e);
+      // exception that would have been silent for producer
+      // propagate for ClaimCheckSerializer to pick up and rethrow
+      StringWriter stackTraceWriter = new StringWriter();
+      PrintWriter out = new PrintWriter(stackTraceWriter);
+      e.printStackTrace(out);
+
+      return new ProducerRecord<>(producerRecord.topic(),
+          producerRecord.partition(),
+          producerRecord.timestamp(),
+          producerRecord.key(),
+          // might as well pass the original to serializer for debugging purposes
+          producerRecord.value(),
+          producerRecord.headers().add(HEADER_MESSAGE_CLAIM_CHECK_ERROR,
+              stackTraceWriter.toString().getBytes(StandardCharsets.UTF_8))
+      );
+    }
+  }
+
+  private boolean isAboveClaimCheckLimit(ProducerRecord<?, ?> originalRecord,
+                                        byte[] keyBytes, byte[] valueBytes) {
+    Headers headers = originalRecord.headers();
+    long timestamp = originalRecord.timestamp() == null ? 0 : originalRecord.timestamp();
+    int batchSizeInBytes = DefaultRecordBatch.sizeInBytes(Collections.singleton(
+        new SimpleRecord(timestamp, keyBytes, valueBytes,
+            headers.toArray())));
+
+    return batchSizeInBytes > checkinUncompressedSizeOverBytes;
+  }
+
+  private boolean isAboveClaimCheckLimit(ProducerRecord<?, ?> originalRecord,
+                                         byte[] keyBytes, long valueSize) {
+    Headers headers = originalRecord.headers();
+    long timestamp = originalRecord.timestamp() == null ? 0 : originalRecord.timestamp();
+    int batchSizeInBytes = DefaultRecordBatch.sizeInBytes(Collections.singleton(
+        new SimpleRecord(timestamp, keyBytes, new byte[] {},
+            headers.toArray())));
+
+    return batchSizeInBytes + valueSize > checkinUncompressedSizeOverBytes;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata recordMetadata, Exception e) {
+    // do nothing by default
+  }
+
+  @Override
+  public void close() {
+    keySerializer.close();
+    claimCheckBackend.close();
+  }
+}

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptor.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptor.java
@@ -80,6 +80,7 @@ public class ClaimCheckStreamingProducerInterceptor<K>
           producerRecord.headers().lastHeader(HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE).value();
       ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
       buffer.put(longBytes);
+      buffer.flip();
       long payloadSize = buffer.getLong();
 
       final byte[] keyBytes = keySerializer.serialize(
@@ -133,17 +134,6 @@ public class ClaimCheckStreamingProducerInterceptor<K>
               stackTraceWriter.toString().getBytes(StandardCharsets.UTF_8))
       );
     }
-  }
-
-  private boolean isAboveClaimCheckLimit(ProducerRecord<?, ?> originalRecord,
-                                        byte[] keyBytes, byte[] valueBytes) {
-    Headers headers = originalRecord.headers();
-    long timestamp = originalRecord.timestamp() == null ? 0 : originalRecord.timestamp();
-    int batchSizeInBytes = DefaultRecordBatch.sizeInBytes(Collections.singleton(
-        new SimpleRecord(timestamp, keyBytes, valueBytes,
-            headers.toArray())));
-
-    return batchSizeInBytes > checkinUncompressedSizeOverBytes;
   }
 
   private boolean isAboveClaimCheckLimit(ProducerRecord<?, ?> originalRecord,

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingUtils.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/ClaimCheckStreamingUtils.java
@@ -1,0 +1,66 @@
+package se.irori.kafka.claimcheck;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+
+/**
+ * Utility methods for Claim Check streaming mode.
+ */
+public class ClaimCheckStreamingUtils {
+
+
+  private static LongSerializer payloadSizeSerializer = new LongSerializer();
+  private static LongDeserializer payloadSizeDeserializer = new LongDeserializer();
+
+  /**
+   * Get the payload size header from a set of message headers.
+   *
+   * @param headers the header set to process
+   * @return the payload size, if header was found
+   * @throws IllegalArgumentException if no header entry was found
+   */
+  public static long getPayloadSize(Headers headers) {
+    Header payloadSizeHeader = headers.lastHeader(
+        ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE);
+    if (payloadSizeHeader == null) {
+      throw new IllegalArgumentException("You must supply the '"
+          + ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE
+          + "' header in streaming mode.");
+    }
+    return payloadSizeDeserializer.deserialize("dummy", payloadSizeHeader.value());
+  }
+
+  /**
+   * Set the payload size header on a set of headers.
+   *
+   * @param headers where to set the header
+   * @param payloadSize value to set
+   */
+  public static void setPayloadSize(Headers headers, long payloadSize) {
+    byte[] payloadSizeBytes = payloadSizeSerializer.serialize("dummy", payloadSize);
+    headers.add(ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE,
+        payloadSizeBytes);
+  }
+
+  /**
+   * Convert an InputStream to a byte array.
+   *
+   * @param dataStream input stream
+   * @param payloadSize number of bytes in input stream
+   * @return a byte array with the fully read stream
+   * @throws IOException in case of read errors
+   */
+  public static byte[] streamToBytes(InputStream dataStream, long payloadSize) throws IOException {
+    byte[] data = new byte[(int) payloadSize];
+    DataInputStream dis = new DataInputStream(dataStream);
+    dis.readFully(data);
+    dis.close();
+    return data;
+  }
+  
+}

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
@@ -1,0 +1,39 @@
+package se.irori.kafka.claimcheck;
+
+import static se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class InputStreamSerializer implements Serializer<InputStream> {
+  @Override
+  public byte[] serialize(String s, InputStream inputStream) {
+    throw new IllegalArgumentException("Need to use Kafka Client library >2.1.0 that passes "
+        + "headers to serializer");
+  }
+
+  @Override
+  public byte[] serialize(String topic, Headers headers, InputStream dataStream) {
+    byte[] longBytes =
+        headers.lastHeader(HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE).value();
+    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+    buffer.put(longBytes);
+    long payloadSize = buffer.getLong();
+
+    byte[] data = new byte[(int) payloadSize];
+    DataInputStream dis = new DataInputStream(dataStream);
+    try {
+      dis.readFully(data);
+      dis.close();
+      return data;
+    } catch (IOException exception) {
+      throw new KafkaException("Error reading message payload input stream", exception);
+    }
+  }
+}

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
@@ -1,16 +1,15 @@
 package se.irori.kafka.claimcheck;
 
-import static se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE;
-
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-
+/**
+ * Serialize InputStreams to bytes, for small streaming mode payloads.
+ */
 public class InputStreamSerializer implements Serializer<InputStream> {
   @Override
   public byte[] serialize(String s, InputStream inputStream) {
@@ -20,12 +19,7 @@ public class InputStreamSerializer implements Serializer<InputStream> {
 
   @Override
   public byte[] serialize(String topic, Headers headers, InputStream dataStream) {
-    byte[] longBytes =
-        headers.lastHeader(HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE).value();
-    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-    buffer.put(longBytes);
-    buffer.flip();
-    long payloadSize = buffer.getLong();
+    long payloadSize = ClaimCheckStreamingProducerInterceptor.getPayloadSize(headers);
 
     byte[] data = new byte[(int) payloadSize];
     DataInputStream dis = new DataInputStream(dataStream);

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
@@ -19,7 +19,7 @@ public class InputStreamSerializer implements Serializer<InputStream> {
 
   @Override
   public byte[] serialize(String topic, Headers headers, InputStream dataStream) {
-    long payloadSize = ClaimCheckStreamingProducerInterceptor.getPayloadSize(headers);
+    long payloadSize = ClaimCheckStreamingUtils.getPayloadSize(headers);
 
     byte[] data = new byte[(int) payloadSize];
     DataInputStream dis = new DataInputStream(dataStream);

--- a/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
+++ b/claim-check-interceptors-core/src/main/java/se/irori/kafka/claimcheck/InputStreamSerializer.java
@@ -24,6 +24,7 @@ public class InputStreamSerializer implements Serializer<InputStream> {
         headers.lastHeader(HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE).value();
     ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
     buffer.put(longBytes);
+    buffer.flip();
     long payloadSize = buffer.getLong();
 
     byte[] data = new byte[(int) payloadSize];

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptorTest.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/ClaimCheckStreamingProducerInterceptorTest.java
@@ -1,0 +1,164 @@
+package se.irori.kafka.claimcheck;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClaimCheckStreamingProducerInterceptorTest {
+
+  ClaimCheckStreamingProducerInterceptor<String> unit;
+
+  @Before
+  public void setup() {
+    unit = new ClaimCheckStreamingProducerInterceptor<>();
+    HashMap<String, Object> config = new HashMap<>();
+    config.put(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_CHECKIN_UNCOMPRESSED_BATCH_SIZE_OVER_BYTES_CONFIG,
+        200);
+
+    FakeClaimCheckBackend.reset();
+    config.put(
+        BaseClaimCheckConfig.Keys.CLAIMCHECK_BACKEND_CLASS_CONFIG, FakeClaimCheckBackend.class);
+
+    config.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ClaimCheckSerializer.class);
+    config.put(BaseClaimCheckConfig.Keys.CLAIMCHECK_WRAPPED_VALUE_SERIALIZER_CLASS,
+        InputStreamSerializer.class);
+
+    config.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    unit.configure(config);
+  }
+
+  @Test
+  public void onSendLargeString() {
+    // GIVEN the interceptor is configured with max limit 200 bytes
+
+    // WHEN sending a record with null key, and body > 100 bytes (with margin)
+    String body = TestUtils.getRandomString(200);
+    byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+
+    ProducerRecord<String, InputStream> producerRecord =
+        new ProducerRecord<>("dummyTopic", new ByteArrayInputStream(bodyBytes));
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(producerRecord.headers(),
+        bodyBytes.length);
+
+    ProducerRecord<String, InputStream> result = unit.onSend(producerRecord);
+
+    assertTrue(ClaimCheckUtils.isClaimCheck(producerRecord.headers()));
+
+    // THEN result should be a claim check reference to the 0 counter value from the dummy impl
+    assertEquals("1", new ClaimCheck(ClaimCheckUtils.getClaimCheckRefFromHeader(
+        result.headers())).getReference());
+    assertEquals(1, FakeClaimCheckBackend.getCount());
+    assertFalse(ClaimCheckUtils.isClaimCheckError(result.headers()));
+  }
+
+  @Test
+  public void onSendSmallString() throws IOException {
+    // GIVEN the interceptor is configured with max limit 200 bytes
+
+    // WHEN sending a record with null key, and body < 100 bytes
+    String body = TestUtils.getRandomString(10);
+    byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+
+    ProducerRecord<String, InputStream> producerRecord =
+        new ProducerRecord<>("dummyTopic", new ByteArrayInputStream(bodyBytes));
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(producerRecord.headers(),
+        bodyBytes.length);
+
+    ProducerRecord<String, InputStream> result = unit.onSend(producerRecord);
+
+    // THEN result should be a claim check reference to the 0 counter value from the dummy impl
+    byte[] outputBytes = new byte[bodyBytes.length];
+    DataInputStream dis = new DataInputStream(result.value());
+    dis.readFully(outputBytes);
+
+    assertEquals(body, new String(outputBytes, StandardCharsets.UTF_8));
+    assertEquals(0, FakeClaimCheckBackend.getCount());
+    assertFalse(ClaimCheckUtils.isClaimCheck(producerRecord.headers()));
+    assertFalse(ClaimCheckUtils.isClaimCheckError(producerRecord.headers()));
+  }
+
+  @Test
+  public void onSendNullString() {
+    // GIVEN the interceptor is configured with max limit 200 bytes
+
+    // WHEN sending a record with null key, and null body
+    ProducerRecord<String, InputStream> producerRecord =
+        new ProducerRecord<>("dummyTopic",
+            null);
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(producerRecord.headers(),
+        0);
+
+    ProducerRecord<String, InputStream> result = unit.onSend(producerRecord);
+
+    // THEN result should be a null value that is not a claim check
+    assertEquals(null, result.value());
+    assertEquals(0, FakeClaimCheckBackend.getCount());
+    assertFalse(ClaimCheckUtils.isClaimCheck(result.headers()));
+    assertFalse(ClaimCheckUtils.isClaimCheckError(result.headers()));
+  }
+
+  @Test
+  public void onSendBackendError() throws IOException {
+    // GIVEN the interceptor is configured with max limit 200 bytes
+    // GIVEN the fake backend is set to throw errors
+    FakeClaimCheckBackend.setErrorModeOn(true);
+
+    // WHEN sending a record with null key, and body > 100 bytes (with margin)
+    String body = TestUtils.getRandomString(200);
+    byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+
+    ProducerRecord<String, InputStream> producerRecord =
+        new ProducerRecord<>("dummyTopic", new ByteArrayInputStream(bodyBytes));
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(producerRecord.headers(),
+        bodyBytes.length);
+
+    ProducerRecord<String, InputStream> result = unit.onSend(producerRecord);
+
+    // THEN result should be a normal message with claim check error header, we called backend
+    byte[] outputBytes = new byte[bodyBytes.length];
+    DataInputStream dis = new DataInputStream(result.value());
+    dis.readFully(outputBytes);
+
+    assertEquals(body, new String(outputBytes, StandardCharsets.UTF_8));
+    assertEquals(1, FakeClaimCheckBackend.getCount());
+    assertFalse(ClaimCheckUtils.isClaimCheck(result.headers()));
+    assertTrue(ClaimCheckUtils.isClaimCheckError(result.headers()));
+
+    String stackTrace = ClaimCheckUtils.getClaimCheckErrorStackTraceFromHeader(
+        result.headers());
+    assertTrue(stackTrace.contains("RuntimeException"));
+    assertTrue(stackTrace.contains("FakeClaimCheckBackend"));
+    assertTrue(stackTrace.contains("ClaimCheckStreamingProducerInterceptor"));
+    assertTrue(stackTrace.contains("Some fake backend exception"));
+
+  }
+
+  @Test
+  public void testPayloadSizeHeaderSerialization() {
+    RecordHeaders headers = new RecordHeaders();
+    long inputSize = 42;
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(headers, inputSize);
+    long outputSize = ClaimCheckStreamingProducerInterceptor.getPayloadSize(headers);
+
+    assertEquals(inputSize, outputSize);
+  }
+
+  @Test
+  public void testSimpleStreamSerialization() {
+
+  }
+}

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/FakeClaimCheckBackend.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/FakeClaimCheckBackend.java
@@ -1,5 +1,6 @@
 package se.irori.kafka.claimcheck;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -38,12 +39,22 @@ public class FakeClaimCheckBackend
   }
 
   @Override
+  public ClaimCheck checkInStreaming(String topic, InputStream payload, long payloadSize) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public byte[] checkOut(ClaimCheck claimCheck) {
     String counterString = (counter++)+"";
     if (errorModeOn) {
       throw new RuntimeException("Some fake backend exception");
     }
     return counterString.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public InputStream checkOutStreaming(ClaimCheck claimCheck) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/FakeClaimCheckBackend.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/FakeClaimCheckBackend.java
@@ -1,5 +1,6 @@
 package se.irori.kafka.claimcheck;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -40,7 +41,11 @@ public class FakeClaimCheckBackend
 
   @Override
   public ClaimCheck checkInStreaming(String topic, InputStream payload, long payloadSize) {
-    throw new UnsupportedOperationException("Not implemented");
+    counter += 1;
+    if (errorModeOn) {
+      throw new RuntimeException("Some fake backend exception");
+    }
+    return new ClaimCheck("" + counter);
   }
 
   @Override
@@ -54,7 +59,11 @@ public class FakeClaimCheckBackend
 
   @Override
   public InputStream checkOutStreaming(ClaimCheck claimCheck) {
-    throw new UnsupportedOperationException("Not implemented");
+    String counterString = (counter++)+"";
+    if (errorModeOn) {
+      throw new RuntimeException("Some fake backend exception");
+    }
+    return new ByteArrayInputStream(counterString.getBytes(StandardCharsets.UTF_8));
   }
 
   @Override

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/InputStreamSerializerTest.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/InputStreamSerializerTest.java
@@ -1,0 +1,66 @@
+package se.irori.kafka.claimcheck;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Test;
+
+public class InputStreamSerializerTest {
+
+  InputStreamSerializer unit = new InputStreamSerializer();
+
+  @Test
+  public void testSimpleSerialization() {
+    // GIVEN some input bytes as an input stream
+    String input = "myInput";
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(inputBytes);
+
+    // WHEN serializing them with the proper payload size header
+    RecordHeaders headers = new RecordHeaders();
+    ClaimCheckStreamingProducerInterceptor.setPayloadSize(headers, inputBytes.length);
+    byte[] outputBytes = unit.serialize("my-topic", headers, inputStream);
+
+    // THEN the output bytes should be the same as the input
+    String output = new String(outputBytes, StandardCharsets.UTF_8);
+    assertEquals(input, output);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoHeader() {
+    // GIVEN some input bytes as an input stream
+    String input = "myInput";
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(inputBytes);
+
+    // WHEN serializing them without  payload size header
+    RecordHeaders headers = new RecordHeaders();
+    byte[] outputBytes = unit.serialize("my-topic", headers, inputStream);
+
+    // THEN expect IllegalArgumentException
+  }
+
+  @Test(expected = SerializationException.class)
+  public void testTooLongSize() {
+    // GIVEN some input bytes as an input stream
+    String input = "myInput";
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(inputBytes);
+
+    // WHEN serializing them with too Long size header
+    RecordHeaders headers = new RecordHeaders();
+    headers.add(ClaimCheckStreamingProducerInterceptor.HEADER_MESSAGE_CLAIM_CHECK_PAYLOAD_SIZE,
+        BigInteger.valueOf(Long.MAX_VALUE).pow(2).toByteArray());
+    byte[] outputBytes = unit.serialize("my-topic", headers, inputStream);
+
+    // THEN expect SerializationException
+  }
+}

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/InputStreamSerializerTest.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/InputStreamSerializerTest.java
@@ -6,7 +6,6 @@ import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.Test;
 
@@ -24,7 +23,7 @@ public class InputStreamSerializerTest {
 
     // WHEN serializing them with the proper payload size header
     RecordHeaders headers = new RecordHeaders();
-    ClaimCheckStreamingProducerInterceptor.setPayloadSize(headers, inputBytes.length);
+    ClaimCheckStreamingUtils.setPayloadSize(headers, inputBytes.length);
     byte[] outputBytes = unit.serialize("my-topic", headers, inputStream);
 
     // THEN the output bytes should be the same as the input

--- a/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/TestUtils.java
+++ b/claim-check-interceptors-core/src/test/java/se/irori/kafka/claimcheck/TestUtils.java
@@ -1,8 +1,12 @@
 package se.irori.kafka.claimcheck;
 
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Random;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
  * Common utility methods for tests.
@@ -27,5 +31,23 @@ public class TestUtils {
     byte[] bytes = new byte[length];
     RANDOM.nextBytes(bytes);
     return bytes;
+  }
+
+  /**
+   * Create a test streaming producer record.
+   *
+   * @param topic record topic
+   * @param key record key
+   * @param value record value
+   * @return a ProducerRecord with value as stream, with proper payload size header
+   */
+  public static ProducerRecord<String, InputStream> streamRecordFromString(
+      String topic, String key, String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream valueStream = new ByteArrayInputStream(bytes);
+    ProducerRecord<String, InputStream> inputRecord =
+        new ProducerRecord<>(topic, key, valueStream);
+    ClaimCheckStreamingUtils.setPayloadSize(inputRecord.headers(), bytes.length);
+    return inputRecord;
   }
 }

--- a/claim-check-test-tools/pom.xml
+++ b/claim-check-test-tools/pom.xml
@@ -18,7 +18,15 @@
   </properties>
 
   <dependencies>
-
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>se.irori.kafka</groupId>
+      <artifactId>claim-check-interceptors-core</artifactId>
+      <version>1.0.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
 

--- a/claim-check-test-tools/src/main/java/se/irori/kafka/claimcheck/TestUtils.java
+++ b/claim-check-test-tools/src/main/java/se/irori/kafka/claimcheck/TestUtils.java
@@ -1,8 +1,12 @@
 package se.irori.kafka.claimcheck;
 
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Random;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
  * Common utility methods for tests.
@@ -45,5 +49,24 @@ public final class TestUtils {
     byte[] bytes = new byte[length];
     RANDOM.nextBytes(bytes);
     return bytes;
+  }
+
+
+  /**
+   * Create a test streaming producer record.
+   *
+   * @param topic record topic
+   * @param key record key
+   * @param value record value
+   * @return a ProducerRecord with value as stream, with proper payload size header
+   */
+  public static ProducerRecord<String, InputStream> streamRecordFromString(
+      String topic, String key, String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    ByteArrayInputStream valueStream = new ByteArrayInputStream(bytes);
+    ProducerRecord<String, InputStream> inputRecord =
+        new ProducerRecord<>(topic, key, valueStream);
+    ClaimCheckStreamingUtils.setPayloadSize(inputRecord.headers(), bytes.length);
+    return inputRecord;
   }
 }


### PR DESCRIPTION
based on InputStreams

```
# producer
# Need to have KafkaProducer<T, InputStream>
# Need to send header message-claim-check-payload-size as Long
interceptor.classes=se.irori.kafka.claimcheck.ClaimCheckStreamingProducerInterceptor
value.serializer.wrapped.serializer=se.irori.kafka.claimcheck.InputStreamSerializer

# consumer
# Need to have KafkaConsumer<T, InputStream>
value.deserializer=se.irori.kafka.claimcheck.ClaimCheckStreamingDeserializer
```